### PR TITLE
Fix exception on first run when there is no Cookie header.

### DIFF
--- a/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -42,7 +42,11 @@ RCT_EXPORT_METHOD(setFromResponse:(NSURL *)url value:(NSDictionary *)value callb
 RCT_EXPORT_METHOD(get:(NSURL *)url callback:(RCTResponseSenderBlock)callback) {
   NSArray *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:url];
     NSDictionary *headers = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
-    callback(@[headers[@"Cookie"], @"success"]);
+    if ([headers objectForKey:@"Cookie"] == nil) {
+        callback(@[[NSNull null], @"success"]);
+    } else {
+        callback(@[headers[@"Cookie"], @"success"]);
+    }
 }
 
 RCT_EXPORT_METHOD(clearAll:(RCTResponseSenderBlock)callback) {


### PR DESCRIPTION
I have no idea what I'm doing with Objective-C but this stops it crashing. :D

To repro, choose Simulator -> Reset Content and Settings… in the iOS Simulator, then install + start UpsideApp.

You'll see this:

![ae516c16-cb34-11e5-9d08-57e6e137299e](https://cloud.githubusercontent.com/assets/1915/12802234/7d94519a-cb36-11e5-97d7-7c16bc6f9a77.png)

Because, of course:

![screen shot 2016-02-04 at 11 44 29](https://cloud.githubusercontent.com/assets/1915/12801936/b37b2ca4-cb34-11e5-8868-8e23a88a67ea.png)
